### PR TITLE
feat: handlers abstraction + queue

### DIFF
--- a/src/lib/handlers/default.ts
+++ b/src/lib/handlers/default.ts
@@ -1,0 +1,9 @@
+import type { Handler } from './types';
+
+const handler = (() => {
+	return (fn: () => void) => {
+		fn();
+	};
+}) satisfies Handler;
+
+export default handler;

--- a/src/lib/handlers/enqueue.ts
+++ b/src/lib/handlers/enqueue.ts
@@ -20,8 +20,12 @@ const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
 			return;
 		}
 		running++;
-		fn();
-		await utils.promise;
+		try {
+			fn();
+			await utils.promise;
+		} catch {
+			/** empty */
+		}
 		running--;
 		const next = queue.pop();
 		if (next) {

--- a/src/lib/handlers/enqueue.ts
+++ b/src/lib/handlers/enqueue.ts
@@ -1,0 +1,34 @@
+import type { Handler } from './types';
+
+type Handle = ReturnType<Handler>;
+type Fn = Parameters<Handle>[0];
+type Utils = Parameters<Handle>[1];
+
+const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
+	let running = 0;
+	const queue: Array<{
+		fn: Fn;
+		utils: Utils;
+	}> = [];
+
+	const handle: Handle = async (fn: () => void, utils) => {
+		if (running >= max) {
+			queue.push({
+				fn,
+				utils,
+			});
+			return;
+		}
+		running++;
+		fn();
+		await utils.promise;
+		running--;
+		const next = queue.pop();
+		if (next) {
+			handle(next.fn, next.utils);
+		}
+	};
+	return handle;
+}) satisfies Handler;
+
+export default handler;

--- a/src/lib/handlers/types.ts
+++ b/src/lib/handlers/types.ts
@@ -2,5 +2,5 @@
 export type Handler = (options?: any) => (
 	fn: () => void,
 
-	utils: { promise: { then: unknown }; abort_controller: AbortController },
+	utils: { promise: Promise<unknown>; abort_controller: AbortController },
 ) => void;

--- a/src/lib/handlers/types.ts
+++ b/src/lib/handlers/types.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Handler = (options?: any) => (
+	fn: () => void,
+
+	utils: { promise: { then: unknown }; abort_controller: AbortController },
+) => void;

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -166,7 +166,7 @@ function is_key(handler: string): handler is HandlerType {
 	return handler in handlers;
 }
 
-for (let handler in handlers) {
+for (const handler in handlers) {
 	if (is_key(handler)) {
 		to_assign[handler] = (gen_or_fun, options) =>
 			_task(gen_or_fun, { kind: is_key(handler) ? handler : 'default', ...(options ?? {}) });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,8 @@
 	);
 
 	let hidden = false;
+
+	let x;
 </script>
 
 <fieldset>
@@ -38,12 +40,13 @@
 	<pre>{JSON.stringify($queue_log, null, '	')}</pre>
 
 	<button
-		on:click={() => {
-			queue_log.perform(Math.random());
+		on:click={async () => {
+			x = queue_log.perform(Math.random());
 		}}
 	>
 		Perform
 	</button>
+	<pre>{JSON.stringify($x, null, '	')}</pre>
 </fieldset>
 
 <fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,8 +9,28 @@
 		return param * 2;
 	});
 
+	const queue_log = task(
+		async (param: number) => {
+			console.log('starting');
+			await new Promise((r) => setTimeout(r, 2000));
+			console.log(param);
+			return param;
+		},
+		{ kind: 'enqueue', max: 3 },
+	);
+
 	let hidden = false;
 </script>
+
+<pre>{JSON.stringify($queue_log, null, '	')}</pre>
+
+<button
+	on:click={() => {
+		queue_log.perform(Math.random());
+	}}
+>
+	Perform
+</button>
 
 <button
 	on:click={() => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,18 +19,45 @@
 		{ kind: 'enqueue', max: 3 },
 	);
 
+	const also_queue_log = task.enqueue(
+		async (param: number) => {
+			console.log('starting');
+			await new Promise((r) => setTimeout(r, 2000));
+			console.log(param);
+			return param;
+		},
+		{ max: 5 },
+	);
+
 	let hidden = false;
 </script>
 
-<pre>{JSON.stringify($queue_log, null, '	')}</pre>
+<fieldset>
+	<legend>queue_log</legend>
 
-<button
-	on:click={() => {
-		queue_log.perform(Math.random());
-	}}
->
-	Perform
-</button>
+	<pre>{JSON.stringify($queue_log, null, '	')}</pre>
+
+	<button
+		on:click={() => {
+			queue_log.perform(Math.random());
+		}}
+	>
+		Perform
+	</button>
+</fieldset>
+
+<fieldset>
+	<legend>also_queue_log</legend>
+	<pre>{JSON.stringify($also_queue_log, null, '	')}</pre>
+
+	<button
+		on:click={() => {
+			also_queue_log.perform(Math.random());
+		}}
+	>
+		Perform
+	</button>
+</fieldset>
 
 <button
 	on:click={() => {


### PR DESCRIPTION
Making this pr so that we can evaluate if we like this abstraction to create handlers...i've implemented the default one and enqueue. 

I'm open to name critiques and also general discussion on the approach. Basically we just have an object with all the handlers and every handler is a factory handler (so that it can have internal state like the queue or stuff like that).

For the moment i've passed the promise and the abort controller to the actual runner so that inside it it can await the promise to make sure the task instance finished running or stop it (we will need it for the restartable)

EDIT: i've also added the automatic creation of a series of shorthands. Basically whenever you add a new handler you will be able to create that handler like this

```ts
task(async ()=>{},{kind: "handler"});
```
AND like this
```ts
task.handler(async ()=>{});
```

all of this with typesafety...so if the handler accept some prop (like `{max:number}` for `enqueue`) you will get intellisense for both cases

eg:

```ts
task(async ()=>{},{kind: "enqueue", max: 2});
```
AND like this
```ts
task.enqueue(async ()=>{}, {max: 2});
```

personally i think it's a nice api and abstraction but eager to see what you think about it.