### PR TITLE
Update renovate config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   check-plan:
-    name: "Check Release Plan"
+    name: 'Check Release Plan'
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check-release.outputs.command }}
@@ -34,7 +34,7 @@ jobs:
         run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
 
   publish:
-    name: "NPM Publish"
+    name: 'NPM Publish'
     runs-on: ubuntu-latest
     needs: check-plan
     if: needs.check-plan.outputs.command == 'release'
@@ -49,14 +49,14 @@ jobs:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-      
+
       - uses: pnpm/action-setup@v3
         with:
           version: 8
       - run: pnpm install --frozen-lockfile
       - name: npm publish
         run: pnpm release-plan publish
-      
+
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,12 @@
 	"semi": true,
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+	"overrides": [
+		{
+			"files": "*.svelte",
+			"options": {
+				"parser": "svelte"
+			}
+		}
+	]
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,21 +4,21 @@ Releases in this repo are mostly automated using [release-plan](https://github.c
 
 ## Preparation
 
-Since the majority of the actual release process is automated, the remaining tasks before releasing are: 
+Since the majority of the actual release process is automated, the remaining tasks before releasing are:
 
--  correctly labeling **all** pull requests that have been merged since the last release
--  updating pull request titles so they make sense to our users
+- correctly labeling **all** pull requests that have been merged since the last release
+- updating pull request titles so they make sense to our users
 
 Some great information on why this is important can be found at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/), but the overall
 guiding principle here is that changelogs are for humans, not machines.
 
 When reviewing merged PR's the labels to be used are:
 
-* breaking - Used when the PR is considered a breaking change.
-* enhancement - Used when the PR adds a new feature or enhancement.
-* bug - Used when the PR fixes a bug included in a previous release.
-* documentation - Used when the PR adds or updates documentation.
-* internal - Internal changes or things that don't fit in any other category.
+- breaking - Used when the PR is considered a breaking change.
+- enhancement - Used when the PR adds a new feature or enhancement.
+- bug - Used when the PR fixes a bug included in a previous release.
+- documentation - Used when the PR adds or updates documentation.
+- internal - Internal changes or things that don't fit in any other category.
 
 **Note:** `release-plan` requires that **all** PRs are labeled. If a PR doesn't fit in a category it's fine to label it as `internal`
 

--- a/package.json
+++ b/package.json
@@ -1,75 +1,75 @@
 {
-  "name": "svelte-concurrency",
-  "version": "0.0.1",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:mainmatter/svelte-concurrency.git"
-  },
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./task": {
-      "types": "./dist/task.d.ts",
-      "import": "./dist/task.js"
-    },
-    "./vite": {
-      "types": "./dist/vite.d.ts",
-      "import": "./dist/vite.js"
-    }
-  },
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/*.spec.*"
-  ],
-  "scripts": {
-    "build": "vite build && npm run package",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "dev": "vite dev",
-    "format": "prettier --write .",
-    "lint": "prettier --check . && eslint .",
-    "package": "svelte-kit sync && svelte-package && publint",
-    "prepublishOnly": "npm run package",
-    "preview": "vite preview",
-    "test": "npm run test:integration && npm run test:unit",
-    "test:integration": "playwright test",
-    "test:unit": "vitest"
-  },
-  "dependencies": {
-    "acorn": "^8.11.3",
-    "esrap": "^1.2.1",
-    "zimmerframe": "^1.1.2"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.42.1",
-    "@sveltejs/adapter-auto": "^3.1.1",
-    "@sveltejs/kit": "^2.5.3",
-    "@sveltejs/package": "^2.3.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.2",
-    "@types/eslint": "8.56.6",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-svelte": "^2.35.1",
-    "prettier": "^3.2.5",
-    "prettier-plugin-svelte": "^3.2.2",
-    "publint": "^0.2.7",
-    "release-plan": "^0.9.0",
-    "svelte": "^4.2.12",
-    "svelte-check": "^3.6.6",
-    "tslib": "^2.6.2",
-    "typescript": "^5.4.2",
-    "vite": "^5.1.5",
-    "vitest": "^1.3.1"
-  },
-  "peerDependencies": {
-    "svelte": "^4.0.0"
-  }
+	"name": "svelte-concurrency",
+	"version": "0.0.1",
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:mainmatter/svelte-concurrency.git"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./task": {
+			"types": "./dist/task.d.ts",
+			"import": "./dist/task.js"
+		},
+		"./vite": {
+			"types": "./dist/vite.d.ts",
+			"import": "./dist/vite.js"
+		}
+	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*"
+	],
+	"scripts": {
+		"build": "vite build && npm run package",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint .",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepublishOnly": "npm run package",
+		"preview": "vite preview",
+		"test": "npm run test:integration && npm run test:unit",
+		"test:integration": "playwright test",
+		"test:unit": "vitest"
+	},
+	"dependencies": {
+		"acorn": "^8.11.3",
+		"esrap": "^1.2.1",
+		"zimmerframe": "^1.1.2"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.42.1",
+		"@sveltejs/adapter-auto": "^3.1.1",
+		"@sveltejs/kit": "^2.5.3",
+		"@sveltejs/package": "^2.3.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@types/eslint": "8.56.6",
+		"@typescript-eslint/eslint-plugin": "^6.21.0",
+		"@typescript-eslint/parser": "^6.21.0",
+		"eslint": "^8.57.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-svelte": "^2.35.1",
+		"prettier": "^3.2.5",
+		"prettier-plugin-svelte": "^3.2.2",
+		"publint": "^0.2.7",
+		"release-plan": "^0.9.0",
+		"svelte": "^4.2.12",
+		"svelte-check": "^3.6.6",
+		"tslib": "^2.6.2",
+		"typescript": "^5.4.2",
+		"vite": "^5.1.5",
+		"vitest": "^1.3.1"
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
+	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"packageRules": [
+		{
+			"extends": ["group:allNonMajor"],
+			"schedule": ["before 7am every friday"],
+			"lockFileMaintenance": {
+				"enabled": true
+			}
+		},
+		{
+			"matchUpdateTypes": ["patch", "pin"],
+			"matchCurrentVersion": "!/^0/"
+		}
+	]
 }


### PR DESCRIPTION
This PR updates the renovate config to group all non-major package upgrades and creates a PR for them once per week, major versions should be separated out into their own PR and all versions should be pinned.

This PR also fixes linting issues that were left over from other commits