### PR TITLE
Add `drop` task

### DIFF
--- a/src/lib/handlers/drop.ts
+++ b/src/lib/handlers/drop.ts
@@ -1,23 +1,22 @@
 import type { Handler } from './types';
 
 type Handle = ReturnType<Handler>;
-type Fn = Parameters<Handle>[0];
 
-const handler = (() => {
-	let running: null | Fn;
+const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
+	let running = 0;
 
 	const handle: Handle = async (fn: () => void, utils) => {
-		if (running) {
+		if (running >= max) {
 			return;
 		}
-		running = fn;
+		running++;
 		try {
 			fn();
 			await utils.promise;
 		} catch {
 			/** empty */
 		}
-		running = null;
+		running--;
 	};
 	return handle;
 }) satisfies Handler;

--- a/src/lib/handlers/drop.ts
+++ b/src/lib/handlers/drop.ts
@@ -1,0 +1,25 @@
+import type { Handler } from './types';
+
+type Handle = ReturnType<Handler>;
+type Fn = Parameters<Handle>[0];
+
+const handler = (() => {
+	let running: null | Fn;
+
+	const handle: Handle = async (fn: () => void, utils) => {
+		if (running) {
+			return;
+		}
+		running = fn;
+		try {
+			fn();
+			await utils.promise;
+		} catch {
+			/** empty */
+		}
+		running = null;
+	};
+	return handle;
+}) satisfies Handler;
+
+export default handler;

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -2,11 +2,13 @@
 import { onDestroy } from 'svelte';
 import { writable } from 'svelte/store';
 import default_handler from './handlers/default';
+import drop from './handlers/drop';
 import enqueue from './handlers/enqueue';
 import restart from './handlers/restart';
 
 const handlers = {
 	default: default_handler,
+	drop,
 	enqueue,
 	restart,
 } as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,11 @@
 		return param;
 	});
 
+	const drop_log = task.drop(async (param: number) => {
+		await new Promise((r) => setTimeout(r, 2000));
+		return param;
+	});
+
 	let hidden = false;
 
 	let x;
@@ -70,6 +75,19 @@
 	<button
 		on:click={() => {
 			restart_log.perform(Math.random());
+		}}
+	>
+		Perform
+	</button>
+</fieldset>
+
+<fieldset>
+	<legend>drop_log</legend>
+	<pre>{JSON.stringify($drop_log, null, '	')}</pre>
+
+	<button
+		on:click={() => {
+			drop_log.perform(Math.random());
 		}}
 	>
 		Perform


### PR DESCRIPTION
This PR adds the `drop` task. Building on the incredible work done in #10, this PR adds the ability to ignore subsequent attempts to start a task while another instance of the task is already running