### PR TITLE
Add `restart` task

### DIFF
--- a/src/lib/handlers/restart.ts
+++ b/src/lib/handlers/restart.ts
@@ -1,0 +1,24 @@
+import type { Handler } from './types';
+
+type Handle = ReturnType<Handler>;
+
+const handler = (() => {
+	let running_controller: null | AbortController;
+
+	const handle: Handle = async (fn: () => void, utils) => {
+		if (running_controller) {
+			running_controller.abort();
+		}
+		running_controller = utils.abort_controller;
+		try {
+			fn();
+			await utils.promise;
+		} catch {
+			/** empty */
+		}
+		running_controller = null;
+	};
+	return handle;
+}) satisfies Handler;
+
+export default handler;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,9 +11,7 @@
 
 	const queue_log = task(
 		async (param: number) => {
-			console.log('starting');
 			await new Promise((r) => setTimeout(r, 2000));
-			console.log(param);
 			return param;
 		},
 		{ kind: 'enqueue', max: 3 },
@@ -21,9 +19,7 @@
 
 	const also_queue_log = task.enqueue(
 		async (param: number) => {
-			console.log('starting');
 			await new Promise((r) => setTimeout(r, 2000));
-			console.log(param);
 			return param;
 		},
 		{ max: 5 },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,6 +29,11 @@
 		{ max: 5 },
 	);
 
+	const restart_log = task.restart(async (param: number) => {
+		await new Promise((r) => setTimeout(r, 2000));
+		return param;
+	});
+
 	let hidden = false;
 
 	let x;
@@ -56,6 +61,19 @@
 	<button
 		on:click={() => {
 			also_queue_log.perform(Math.random());
+		}}
+	>
+		Perform
+	</button>
+</fieldset>
+
+<fieldset>
+	<legend>restart_log</legend>
+	<pre>{JSON.stringify($restart_log, null, '	')}</pre>
+
+	<button
+		on:click={() => {
+			restart_log.perform(Math.random());
 		}}
 	>
 		Perform

--- a/src/routes/Child.svelte
+++ b/src/routes/Child.svelte
@@ -11,12 +11,19 @@
 		alert('Child finished');
 		return num * 2;
 	});
+
+	let num: ReturnType<typeof child.perform>;
 </script>
 
 <button
 	on:click={async () => {
-		const num = await child.perform();
-		alert(`Result: ${num}`);
+		num = child.perform();
+		alert(`Result: ${await num}`);
 	}}>Perform child</button
+>
+<button
+	on:click={() => {
+		num.cancel();
+	}}>cancel child last instance</button
 >
 <pre>{JSON.stringify($child, null, '	')}</pre>


### PR DESCRIPTION
This is currently WIP, I'm having trouble cancelling the current task instance. The `abort_controller` seems to have two difference instances, the one in the task and the one in the handler, aborting the one in the task doesn't abort the one in the handler, meaning that the promise still resolves even if the controller has been aborted