### PR TITLE
fix: abort when dropping

### DIFF
--- a/src/lib/handlers/drop.ts
+++ b/src/lib/handlers/drop.ts
@@ -7,6 +7,7 @@ const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
 
 	const handle: Handle = async (fn: () => void, utils) => {
 		if (running >= max) {
+			utils.abort_controller.abort();
 			return;
 		}
 		running++;


### PR DESCRIPTION
We should probably abort the controller when we drop a task to give the user a way of checking if the task instance was cancelled