### PR TITLE
chore: restructure testing and add tests for enqueue

### DIFF
--- a/src/lib/tests/components/enqueue.svelte
+++ b/src/lib/tests/components/enqueue.svelte
@@ -8,9 +8,10 @@
 
 	export let return_value: (value: unknown) => void = () => {};
 	export let argument = 0;
+	export let max = 1;
 
-	const default_task = task.default(fn);
-	const options_task = task(fn, { kind: 'default' });
+	const default_task = task.enqueue(fn, { max });
+	const options_task = task(fn, { kind: 'enqueue', max });
 
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -5,145 +5,237 @@ import type { SvelteConcurrencyUtils } from '$lib/task';
 import { render } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import Default from './components/default.svelte';
+import Enqueue from './components/enqueue.svelte';
 
 function wait(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-describe('task - default handler', () => {
-	it('calls the function you pass in', async () => {
-		const fn = vi.fn();
-		const { getByTestId } = render(Default, {
-			fn,
+function all_options(fn: (selector: string) => void) {
+	describe.each(['default', 'options'])('version with %s', fn);
+}
+
+describe.each([
+	{ component: Default, name: 'default' },
+	{ component: Enqueue, name: 'enqueue' },
+])('task - basic functionality $name', ({ component }) => {
+	all_options((selector) => {
+		it('calls the function you pass in', async () => {
+			const fn = vi.fn();
+			const { getByTestId } = render(component, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalled();
+			});
 		});
-		const perform = getByTestId('perform-default');
-		perform.click();
-		await vi.waitFor(() => {
-			expect(fn).toHaveBeenCalled();
+
+		it("runs to completion if it's not cancelled", async () => {
+			let count = 0;
+			const wait_time = 2000;
+			async function* fn() {
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(component, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			await vi.waitFor(
+				() => {
+					expect(count).toBe(1);
+				},
+				{
+					timeout: 3000,
+				},
+			);
+		});
+
+		it("doesn't runs to completion if it's cancelled, the function is a generator and there's a yield after every await", async () => {
+			let count = 0;
+			const wait_time = 2000;
+			let task_signal: AbortSignal;
+			async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
+				task_signal = signal;
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(component, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}`);
+			perform.click();
+			await wait(500);
+			cancel.click();
+			await vi.waitFor(() => {
+				expect(task_signal.aborted).toBeTruthy();
+			});
+			expect(count).toBe(0);
+		});
+
+		it("if awaited returns the value it's returned from the function", async () => {
+			const returned_value = 42;
+			const fn = vi.fn(async () => {
+				return returned_value;
+			});
+			const return_value = vi.fn();
+			const { getByTestId } = render(component, {
+				fn,
+				return_value,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalled();
+			});
+			expect(return_value).toHaveBeenCalledWith(returned_value);
+		});
+
+		it('passing a value to perform passes the same value as the first argument of the function', async () => {
+			let passed_in_value = 0;
+			const argument = 42;
+			const fn = vi.fn(async (value) => {
+				passed_in_value = value;
+			});
+			const { getByTestId } = render(component, {
+				fn,
+				argument,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalled();
+			});
+			expect(passed_in_value).toBe(argument);
 		});
 	});
+});
 
-	it("runs to completion if it's not cancelled", async () => {
-		let count = 0;
-		const wait_time = 2000;
-		async function* fn() {
+describe("task - specific functionality 'default'", () => {
+	all_options((selector) => {
+		it('runs multiple time if performed multiple time', async () => {
+			const fn = vi.fn();
+			const { getByTestId } = render(Default, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			perform.click();
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalledTimes(3);
+			});
+		});
+
+		it('passing a value to perform passes the same value as the first argument of the function', async () => {
+			let passed_in_value = 0;
+			const argument = 42;
+			const fn = vi.fn(async (value) => {
+				passed_in_value = value;
+			});
+			const { getByTestId } = render(Default, {
+				fn,
+				argument,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalled();
+			});
+			expect(passed_in_value).toBe(argument);
+		});
+
+		it("cancel the last instance if you call cancel on the returned instance, the function is a generator and there's a yield after every await", async () => {
+			let count = 0;
+			const wait_time = 2000;
+			let task_signal: AbortSignal;
+			async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
+				task_signal = signal;
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(Default, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}-last`);
+			perform.click();
+			perform.click();
+			perform.click();
+			await wait(500);
+			cancel.click();
+			await vi.waitFor(() => {
+				expect(task_signal.aborted).toBeTruthy();
+			});
 			await wait(wait_time);
-			yield;
-			count++;
-		}
-		const { getByTestId } = render(Default, {
-			fn,
+			expect(count).toBe(2);
 		});
-		const perform = getByTestId('perform-default');
-		perform.click();
-		await vi.waitFor(
-			() => {
-				expect(count).toBe(1);
-			},
-			{
-				timeout: 3000,
-			},
-		);
 	});
+});
 
-	it("doesn't runs to completion if it's cancelled, the function is a generator and there's a yield after every await", async () => {
-		let count = 0;
-		const wait_time = 2000;
-		let task_signal: AbortSignal;
-		async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
-			task_signal = signal;
+describe("task - specific functionality 'enqueue'", () => {
+	all_options((selector) => {
+		it('runs multiple time if performed multiple time but only `max` at a time', async () => {
+			let concurrent = 0;
+			let max_concurrent = -Infinity;
+			const fn = vi.fn(async () => {
+				concurrent++;
+				max_concurrent = Math.max(max_concurrent, concurrent);
+				await wait(200);
+				concurrent--;
+			});
+			const { getByTestId } = render(Enqueue, {
+				fn,
+				max: 1,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			perform.click();
+			perform.click();
+			perform.click();
+			await vi.waitFor(() => {
+				expect(fn).toHaveBeenCalledTimes(3);
+			});
+			expect(max_concurrent).toBe(1);
+		});
+
+		it("cancel the last instance if you call cancel on the returned instance, the function is a generator and there's a yield after every await", async () => {
+			let count = 0;
+			const wait_time = 600;
+			const task_signals: AbortSignal[] = [];
+			async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
+				task_signals.push(signal);
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(Enqueue, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}-last`);
+			perform.click();
+			perform.click();
+			perform.click();
+			await vi.waitFor(
+				() => {
+					expect(task_signals.length).toBe(3);
+				},
+				{ timeout: wait_time * 3 },
+			);
+			await wait(500);
+			cancel.click();
+			await vi.waitFor(() => {
+				expect(task_signals[2].aborted).toBeTruthy();
+			});
 			await wait(wait_time);
-			yield;
-			count++;
-		}
-		const { getByTestId } = render(Default, {
-			fn,
+			expect(count).toBe(2);
 		});
-		const perform = getByTestId('perform-default');
-		const cancel = getByTestId('cancel-default');
-		perform.click();
-		await wait(500);
-		cancel.click();
-		await vi.waitFor(() => {
-			expect(task_signal.aborted).toBeTruthy();
-		});
-		expect(count).toBe(0);
-	});
-
-	it('runs multiple time if performed multiple time', async () => {
-		const fn = vi.fn();
-		const { getByTestId } = render(Default, {
-			fn,
-		});
-		const perform = getByTestId('perform-default');
-		perform.click();
-		perform.click();
-		perform.click();
-		await vi.waitFor(() => {
-			expect(fn).toHaveBeenCalledTimes(3);
-		});
-	});
-
-	it("if awaited returns the value it's returned from the function", async () => {
-		const returned_value = 42;
-		const fn = vi.fn(async () => {
-			return returned_value;
-		});
-		const return_value = vi.fn();
-		const { getByTestId } = render(Default, {
-			fn,
-			return_value,
-		});
-		const perform = getByTestId('perform-default');
-		perform.click();
-		await vi.waitFor(() => {
-			expect(fn).toHaveBeenCalled();
-		});
-		expect(return_value).toHaveBeenCalledWith(returned_value);
-	});
-
-	it('passing a value to perform passes the same value as the first argument of the function', async () => {
-		let passed_in_value = 0;
-		const argument = 42;
-		const fn = vi.fn(async (value) => {
-			passed_in_value = value;
-		});
-		const { getByTestId } = render(Default, {
-			fn,
-			argument,
-		});
-		const perform = getByTestId('perform-default');
-		perform.click();
-		await vi.waitFor(() => {
-			expect(fn).toHaveBeenCalled();
-		});
-		expect(passed_in_value).toBe(argument);
-	});
-
-	it("cancel the last instance if you call cancel on the returned instance, the function is a generator and there's a yield after every await", async () => {
-		let count = 0;
-		const wait_time = 2000;
-		let task_signal: AbortSignal;
-		async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
-			task_signal = signal;
-			await wait(wait_time);
-			yield;
-			count++;
-		}
-		const { getByTestId } = render(Default, {
-			fn,
-		});
-		const perform = getByTestId('perform-default');
-		const cancel = getByTestId('cancel-default-last');
-		perform.click();
-		perform.click();
-		perform.click();
-		await wait(500);
-		cancel.click();
-		await vi.waitFor(() => {
-			expect(task_signal.aborted).toBeTruthy();
-		});
-		await wait(wait_time);
-		expect(count).toBe(2);
 	});
 });


### PR DESCRIPTION
I've restructured testing so that we can easily test the basic functionality for every test modifier and also add specific cases for each of them. To showcase how it works i've also added tests for `enqueue`. I will add the rest of the task modifiers as soon as this is merged.