### PR TITLE
Add keep_latest

### DIFF
--- a/src/lib/handlers/keep_latest.ts
+++ b/src/lib/handlers/keep_latest.ts
@@ -1,0 +1,38 @@
+import type { Handler } from './types';
+
+type Handle = ReturnType<Handler>;
+type Fn = Parameters<Handle>[0];
+type Utils = Parameters<Handle>[1];
+
+const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
+	let running = 0;
+	const queue: Array<{
+		fn: Fn;
+		utils: Utils;
+	}> = [];
+
+	const handle: Handle = async (fn: () => void, utils) => {
+		if (running >= max) {
+			const latest = queue.pop();
+			latest?.utils.abort_controller.abort();
+			queue.push({ fn, utils });
+			return;
+		}
+		running++;
+		try {
+			fn();
+			await utils.promise;
+		} catch {
+			/** empty */
+		}
+		running--;
+
+		const next = queue.shift();
+		if (next) {
+			handle(next.fn, next.utils);
+		}
+	};
+	return handle;
+}) satisfies Handler;
+
+export default handler;

--- a/src/lib/handlers/keep_latest.ts
+++ b/src/lib/handlers/keep_latest.ts
@@ -6,16 +6,17 @@ type Utils = Parameters<Handle>[1];
 
 const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
 	let running = 0;
-	const queue: Array<{
-		fn: Fn;
-		utils: Utils;
-	}> = [];
+	let latest:
+		| {
+				fn: Fn;
+				utils: Utils;
+		  }
+		| undefined = undefined;
 
 	const handle: Handle = async (fn: () => void, utils) => {
 		if (running >= max) {
-			const latest = queue.pop();
 			latest?.utils.abort_controller.abort();
-			queue.push({ fn, utils });
+			latest = { fn, utils };
 			return;
 		}
 		running++;
@@ -27,9 +28,9 @@ const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
 		}
 		running--;
 
-		const next = queue.shift();
-		if (next) {
-			handle(next.fn, next.utils);
+		if (latest) {
+			handle(latest.fn, latest.utils);
+			latest = undefined;
 		}
 	};
 	return handle;

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -4,12 +4,14 @@ import { writable } from 'svelte/store';
 import default_handler from './handlers/default';
 import drop from './handlers/drop';
 import enqueue from './handlers/enqueue';
+import keep_latest from './handlers/keep_latest';
 import restart from './handlers/restart';
 
 const handlers = {
 	default: default_handler,
 	drop,
 	enqueue,
+	keepLatest: keep_latest,
 	restart,
 } as const;
 

--- a/src/lib/tests/components/keep_latest.svelte
+++ b/src/lib/tests/components/keep_latest.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { task, type SvelteConcurrencyUtils } from '../../task';
+
+	export let fn: (
+		args: number,
+		utils: SvelteConcurrencyUtils,
+	) => Promise<unknown> | AsyncGenerator<unknown, unknown, unknown>;
+
+	export let return_value: (value: unknown) => void = () => {};
+	export let argument = 0;
+	export let max = 1;
+
+	const default_task = task.keepLatest(fn, { max });
+	const options_task = task(fn, { kind: 'keepLatest', max });
+
+	let latest_task_instance: ReturnType<typeof default_task.perform>;
+	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
+</script>
+
+<button
+	data-testid="perform-default"
+	on:click={async () => {
+		latest_task_instance = default_task.perform(argument);
+		return_value(await latest_task_instance);
+	}}>perform</button
+>
+
+<button
+	data-testid="perform-options"
+	on:click={async () => {
+		latest_options_task_instance = options_task.perform(argument);
+		return_value(await latest_options_task_instance);
+	}}>perform options</button
+>
+
+<button
+	data-testid="cancel-default"
+	on:click={() => {
+		default_task.cancelAll();
+	}}>cancel</button
+>
+
+<button
+	data-testid="cancel-options"
+	on:click={() => {
+		options_task.cancelAll();
+	}}>cancel options</button
+>
+
+<button
+	data-testid="cancel-default-last"
+	on:click={() => {
+		if (latest_task_instance) {
+			latest_task_instance.cancel();
+		}
+	}}>cancel last instance</button
+>
+
+<button
+	data-testid="cancel-options-last"
+	on:click={() => {
+		if (latest_options_task_instance) {
+			latest_options_task_instance.cancel();
+		}
+	}}>cancel last options instance</button
+>
+
+<button
+	data-testid="perform-error"
+	on:click={async () => {
+		try {
+			await default_task.perform(argument);
+		} catch (e) {
+			return_value({
+				error: e,
+				store: default_task,
+			});
+		}
+	}}>perform</button
+>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -41,9 +41,19 @@
 		return param;
 	});
 
+	const latest_log = task(
+		async (param: number) => {
+			await new Promise((r) => setTimeout(r, 2000));
+			return param;
+		},
+		{ kind: 'keepLatest', max: 3 },
+	);
+
 	let hidden = false;
 
 	let x;
+
+	let numbers: number[] = [];
 </script>
 
 <fieldset>
@@ -98,6 +108,35 @@
 	>
 		Perform
 	</button>
+</fieldset>
+
+<fieldset>
+	<legend>latest_log</legend>
+	<pre>{JSON.stringify($latest_log, null, '	')}</pre>
+
+	<button
+		on:click={() => {
+			const num = Math.random();
+			numbers = [...numbers, num];
+			latest_log.perform(num);
+		}}
+	>
+		Perform
+	</button>
+	<button
+		on:click={() => {
+			numbers = [];
+		}}
+	>
+		Clear numbers
+	</button>
+	<ul>
+		{#each numbers as number}
+			<li>
+				{number}
+			</li>
+		{/each}
+	</ul>
 </fieldset>
 
 <button


### PR DESCRIPTION
This PR adds the `keep_latest` task type. 
Copying from ember-concurrency, `keep_latest` will create a queue of subsequent tasks but only run the most recent addition when the current instance has completed