### PR TITLE
feat: better async transform (yield replace await)

### DIFF
--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -116,7 +116,7 @@ function _task<TArgs = undefined, TReturn = unknown>(
 									if (abort_controller.signal.aborted) {
 										break;
 									}
-									next_val = await gen_or_value.next();
+									next_val = await gen_or_value.next(next_val.value);
 								}
 								if (next_val.done) {
 									const last_result = next_val.value;

--- a/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
+++ b/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
@@ -7,87 +7,31 @@ function fn(val) {
 function str(quasi, strings) {}
 
 task(async function* () {
-	const assign = await Promise.resolve();
-
-	yield;
-
-	const array = [await Promise.resolve()];
-
-	yield;
-
-	const sum = await Promise.resolve(1) + 2;
-
-	yield;
-
-	const sum2 = 2 + await Promise.resolve(1);
-
-	yield;
-
-	const function_call = fn(await Promise.resolve(2));
-
-	yield;
-
-	const conditional1 = await Promise.resolve(true) ? 1 : 2;
-
-	yield;
-
-	const conditional2 = true ? await Promise.resolve(1) : 2;
-
-	yield;
-
-	const conditional3 = false ? 1 : await Promise.resolve(2);
-
-	yield;
-
-	const logical1 = await Promise.resolve(null) ?? 3;
-
-	yield;
-
-	const logical2 = null ?? await Promise.resolve(null);
-
-	yield;
-
-	const logical3 = null || await Promise.resolve(null);
-
-	yield;
-
-	const logical4 = await Promise.resolve(null) || null;
-
-	yield;
-
-	const logical5 = await Promise.resolve(null) && null;
-
-	yield;
-
-	const logical6 = true && await Promise.resolve(null);
-
-	yield;
-
-	const object_expression1 = { awaited: await Promise.resolve(2) };
-
-	yield;
+	const assign = yield Promise.resolve();
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
 
 	const object_expression2 = {
-		awaited: { nested: await Promise.resolve(2) }
+		awaited: { nested: yield Promise.resolve(2) }
 	};
-
-	yield;
 
 	const object_expression3 = {
-		awaited: { nested: [await Promise.resolve(2)] }
+		awaited: { nested: [yield Promise.resolve(2)] }
 	};
 
-	yield;
-
-	const tagged_template = str`something ${await Promise.resolve("")}`;
-
-	yield;
-
-	const template_literal = `something ${await Promise.resolve("")}`;
-
-	yield;
-
-	const unary = !await Promise.resolve(true);
-
-	yield;
+	const tagged_template = str`something ${yield Promise.resolve("")}`;
+	const template_literal = `something ${yield Promise.resolve("")}`;
+	const unary = !(yield Promise.resolve(true));
 });

--- a/src/lib/tests/expected-transforms/add-yield-after-await/transform.js
+++ b/src/lib/tests/expected-transforms/add-yield-after-await/transform.js
@@ -1,6 +1,5 @@
 import { task } from "svelte-concurrency";
 
 task(async function* () {
-	await Promise.resolve();
-	yield;
+	yield Promise.resolve();
 });

--- a/src/lib/tests/expected-transforms/add-yield-after-multiple-await/transform.js
+++ b/src/lib/tests/expected-transforms/add-yield-after-multiple-await/transform.js
@@ -1,8 +1,6 @@
 import { task } from "svelte-concurrency";
 
 task(async function* () {
-	await Promise.resolve();
-	yield;
-	await Promise.resolve();
-	yield;
+	yield Promise.resolve();
+	yield Promise.resolve();
 });

--- a/src/lib/tests/expected-transforms/task-aliased-plus-task-from-another-library/transform.js
+++ b/src/lib/tests/expected-transforms/task-aliased-plus-task-from-another-library/transform.js
@@ -7,8 +7,6 @@ task(async () => {
 });
 
 other_name(async function* () {
-	await Promise.resolve();
-	yield;
-	await Promise.resolve();
-	yield;
+	yield Promise.resolve();
+	yield Promise.resolve();
 });

--- a/src/lib/tests/expected-transforms/task-aliased-plus-task-function/transform.js
+++ b/src/lib/tests/expected-transforms/task-aliased-plus-task-function/transform.js
@@ -10,8 +10,6 @@ task(async () => {
 });
 
 other_name(async function* () {
-	await Promise.resolve();
-	yield;
-	await Promise.resolve();
-	yield;
+	yield Promise.resolve();
+	yield Promise.resolve();
 });

--- a/src/lib/tests/expected-transforms/task-aliased/transform.js
+++ b/src/lib/tests/expected-transforms/task-aliased/transform.js
@@ -1,8 +1,6 @@
 import { task as other_name } from "svelte-concurrency";
 
 other_name(async function* () {
-	await Promise.resolve();
-	yield;
-	await Promise.resolve();
-	yield;
+	yield Promise.resolve();
+	yield Promise.resolve();
 });


### PR DESCRIPTION
So after today discussion i couldn't bother not trying this.

I've passed back the value from the awaited next if the function is a generator allowing for a syntax like this

```ts
task(async function*(){
    const value = yield fetch("something");
});
```
this still sucks in TS so we should still recommend users to do this
```ts
task(async function*(){
    const value = await fetch("something");
    yield;
});
```

BUT

this allow us to change the async transform to transform this
```ts
task(async() => {
    const value = await fetch("something");
});
```
into this
```ts
task(async function*(){
    const value = yield fetch("something");
});
```

the advantage of this is that if the task is aborted while the promise still hasn't resolved after it resolve we don't assign to value which could be much better if value was a reactive variable in svelte.

In this PR i've also updated the vite plugin to apply this better transform (you can see how the transform change in the generated test files)