### PR TITLE
chore: test for errors thrown in perform

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
 import { task } from './task.js';
-export type { Task } from './task.js';
+export type { Task, SvelteConcurrencyUtils } from './task.js';
 
 export { task };

--- a/src/lib/tests/components/default.svelte
+++ b/src/lib/tests/components/default.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type SvelteConcurrencyUtils } from '../../task';
+	import { task, type SvelteConcurrencyUtils } from '../../index';
 
 	export let fn: (
 		args: number,
@@ -62,4 +62,18 @@
 			latest_options_task_instance.cancel();
 		}
 	}}>cancel last options instance</button
+>
+
+<button
+	data-testid="perform-error"
+	on:click={async () => {
+		try {
+			await default_task.perform(argument);
+		} catch (e) {
+			return_value({
+				error: e,
+				store: default_task,
+			});
+		}
+	}}>perform</button
 >

--- a/src/lib/tests/components/drop.svelte
+++ b/src/lib/tests/components/drop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type SvelteConcurrencyUtils } from '../../task';
+	import { task, type SvelteConcurrencyUtils } from '../../index';
 
 	export let fn: (
 		args: number,
@@ -63,4 +63,18 @@
 			latest_options_task_instance.cancel();
 		}
 	}}>cancel last options instance</button
+>
+
+<button
+	data-testid="perform-error"
+	on:click={async () => {
+		try {
+			await default_task.perform(argument);
+		} catch (e) {
+			return_value({
+				error: e,
+				store: default_task,
+			});
+		}
+	}}>perform</button
 >

--- a/src/lib/tests/components/enqueue.svelte
+++ b/src/lib/tests/components/enqueue.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type SvelteConcurrencyUtils } from '../../task';
+	import { task, type SvelteConcurrencyUtils } from '../../index';
 
 	export let fn: (
 		args: number,
@@ -63,4 +63,18 @@
 			latest_options_task_instance.cancel();
 		}
 	}}>cancel last options instance</button
+>
+
+<button
+	data-testid="perform-error"
+	on:click={async () => {
+		try {
+			await default_task.perform(argument);
+		} catch (e) {
+			return_value({
+				error: e,
+				store: default_task,
+			});
+		}
+	}}>perform</button
 >

--- a/src/lib/tests/components/link/child.svelte
+++ b/src/lib/tests/components/link/child.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type Task } from '../../../task';
+	import { task, type Task } from '../../../index';
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	export let parent: Task<number, any>;

--- a/src/lib/tests/components/link/parent.svelte
+++ b/src/lib/tests/components/link/parent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type SvelteConcurrencyUtils } from '../../../task';
+	import { task, type SvelteConcurrencyUtils } from '../../../index';
 	import Child from './child.svelte';
 
 	export let fn: (

--- a/src/lib/tests/components/restart.svelte
+++ b/src/lib/tests/components/restart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { task, type SvelteConcurrencyUtils } from '../../task';
+	import { task, type SvelteConcurrencyUtils } from '../../index';
 
 	export let fn: (
 		args: number,
@@ -63,4 +63,18 @@
 			latest_options_task_instance.cancel();
 		}
 	}}>cancel last options instance</button
+>
+
+<button
+	data-testid="perform-error"
+	on:click={async () => {
+		try {
+			await default_task.perform(argument);
+		} catch (e) {
+			return_value({
+				error: e,
+				store: default_task,
+			});
+		}
+	}}>perform</button
 >

--- a/src/lib/tests/components/wrong-kind.svelte
+++ b/src/lib/tests/components/wrong-kind.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import { task } from '../../index';
+
+	// @ts-expect-error something doesn't exists
+	task(async () => {}, { kind: 'something' });
+</script>

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -143,7 +143,7 @@ describe.each([
 });
 
 describe('task - error if wrong kind', () => {
-	it('throws if you try to instanciate a task with the wrong kind', () => {
+	it('throws if you try to instantiate a task with the wrong kind', () => {
 		expect(() => render(WrongKind)).toThrowErrorMatchingInlineSnapshot(
 			`[Error: Unexpected kind 'something']`,
 		);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vitest/config';
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig(({ mode }) => ({
 	plugins: [sveltekit()],
@@ -9,5 +9,13 @@ export default defineConfig(({ mode }) => ({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		setupFiles: './src/vitest-setup.ts',
+		coverage: {
+			exclude: [
+				'src/routes/**/*',
+				'src/lib/tests/expected-transforms/generate-expected.ts',
+				'*.[j|t]s',
+				...coverageConfigDefaults.exclude,
+			],
+		},
 	},
 }));


### PR DESCRIPTION
Closes #70 

Added the last bit of coverage needed...it's not needed but it does feel cool

<img width="1490" alt="image" src="https://github.com/mainmatter/svelte-concurrency/assets/26281609/7551878e-a1b9-4a79-95d1-641f030dc752">
