### PR TITLE
chore: use pnpm 9 in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: 9
       - run: pnpm i --frozen-lockfile
       - run: pnpm run lint

--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - run: pnpm install --frozen-lockfile
 
       - name: 'Generate Explanation and Prep Changelogs'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - run: pnpm install --frozen-lockfile
       - name: npm publish
         run: pnpm release-plan publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: 9
       - run: pnpm i --frozen-lockfile
       - run: pnpm run test


### PR DESCRIPTION
We should use latest pnpm in workflows (`release-plan` is also failing because of this)