### PR TITLE
Add TaskInstance and derive `last`

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
 import { task } from './task.js';
-export type { Task, SvelteConcurrencyUtils } from './task.js';
+export type { Task, SvelteConcurrencyUtils, TaskInstance } from './task.js';
 
 export { task };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
 import { task } from './task.js';
-export type { Task, SvelteConcurrencyUtils, TaskInstance } from './task.js';
+export type { Task, SvelteConcurrencyUtils, TaskDerivedState } from './task.js';
 
 export { task };

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -6,7 +6,7 @@ export type { SvelteConcurrencyUtils, TaskOptions };
 
 export type Task<TArgs = unknown, TReturn = unknown> = ReturnType<typeof task<TArgs, TReturn>>;
 
-export type TaskInstance<TReturn = undefined> = {
+export type TaskDerivedState<TReturn = undefined> = {
 	error?: undefined | unknown;
 	isCanceled: boolean;
 	isError: boolean;
@@ -26,17 +26,17 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 
 	const { subscribe, ...result } = writable({
 		isRunning: false,
-		last: undefined as undefined | TaskInstance<TReturn>,
-		lastCanceled: undefined as undefined | TaskInstance<TReturn>,
-		lastErrored: undefined as undefined | TaskInstance<TReturn>,
-		lastRunning: undefined as undefined | TaskInstance<TReturn>,
-		lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
+		last: undefined as undefined | TaskDerivedState<TReturn>,
+		lastCanceled: undefined as undefined | TaskDerivedState<TReturn>,
+		lastErrored: undefined as undefined | TaskDerivedState<TReturn>,
+		lastRunning: undefined as undefined | TaskDerivedState<TReturn>,
+		lastSuccessful: undefined as undefined | TaskDerivedState<TReturn>,
 		results,
 		performCount: 0,
 	});
 
 	const updateResult = (
-		instance: TaskInstance<TReturn> | undefined,
+		instance: TaskDerivedState<TReturn> | undefined,
 		new_instance: boolean = false,
 	) => {
 		return result.update((old) => {
@@ -67,7 +67,7 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 		});
 	};
 
-	const instances = new Map<string, TaskInstance<TReturn>>();
+	const instances = new Map<string, TaskDerivedState<TReturn>>();
 
 	const actual_task = createTask<TArgs, TReturn>(
 		{

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -21,6 +21,12 @@ function all_options(fn: (selector: string) => void) {
 	describe.each(['default', 'options'])('version with %s', fn);
 }
 
+//last
+//lastErrored
+//lastCanceled
+//lastSuccessful
+//lastRunning
+
 describe.each([
 	{
 		component: Default,
@@ -244,7 +250,7 @@ describe.each([
 		expect(returned_value).toBeDefined();
 		if (!returned_value) throw new Error('No returned value');
 		expect(returned_value.error).toBe(to_throw);
-		expect(get(returned_value.store).error).toBe(to_throw);
+		expect(get(returned_value.store).last?.error).toBe(to_throw);
 	});
 });
 


### PR DESCRIPTION
WIP: still need to add tests and docs

This PR moves the task specific details into the `TaskInstance` interface and uses that to update the `Task` derived state

Closes #82
Closes #85 
Closes #86 
Closes #83