### PR TITLE
fix: cancelled instances hanging indefinitely

### DIFF
--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -42,7 +42,7 @@ type TaskAdapter<TReturn = unknown> = {
 
 export class CancelationError extends Error {
 	constructor() {
-		super('CancelationError: the task instance was cancelled' + new Date().getTime());
+		super('CancelationError: the task instance was cancelled');
 		super.name = 'CancelationError';
 	}
 }

--- a/src/lib/handlers/restart.ts
+++ b/src/lib/handlers/restart.ts
@@ -3,20 +3,22 @@ import type { Handler } from './types';
 type Handle = ReturnType<Handler>;
 
 const handler = (({ max = 1 }: { max?: number } = { max: 1 }) => {
-	const running_controllers: AbortController[] = [];
+	const running_controllers = new Set<AbortController>();
 
 	const handle: Handle = async (fn: () => void, utils) => {
-		if (running_controllers.length >= max) {
-			running_controllers.shift()?.abort();
+		if (running_controllers.size >= max) {
+			const first = running_controllers.values().next();
+			first.value?.abort();
+			running_controllers.delete(first.value);
 		}
-		running_controllers.push(utils.abort_controller);
+		running_controllers.add(utils.abort_controller);
 		try {
 			fn();
 			await utils.promise;
 		} catch {
 			/** empty */
 		}
-		running_controllers.pop();
+		running_controllers.delete(utils.abort_controller);
 	};
 	return handle;
 }) satisfies Handler;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
-import { task } from './task.js';
+import { task, CancelationError } from './task.js';
 export type { Task, SvelteConcurrencyUtils, TaskDerivedState } from './task.js';
 
-export { task };
+export { task, CancelationError };

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -1,8 +1,10 @@
 import { onDestroy } from 'svelte';
-import { createTask, handlers } from './core';
+import { createTask, handlers, CancelationError } from './core';
 import { writable } from 'svelte/store';
 import type { SvelteConcurrencyUtils, TaskOptions, HandlerType, HandlersMap } from './core';
 export type { SvelteConcurrencyUtils, TaskOptions };
+
+export { CancelationError };
 
 export type Task<TArgs = unknown, TReturn = unknown> = ReturnType<typeof task<TArgs, TReturn>>;
 

--- a/src/lib/tests/components/default.svelte
+++ b/src/lib/tests/components/default.svelte
@@ -19,16 +19,24 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform options</button
 >
 

--- a/src/lib/tests/components/drop.svelte
+++ b/src/lib/tests/components/drop.svelte
@@ -20,16 +20,24 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform options</button
 >
 

--- a/src/lib/tests/components/enqueue.svelte
+++ b/src/lib/tests/components/enqueue.svelte
@@ -20,16 +20,24 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform options</button
 >
 

--- a/src/lib/tests/components/keep_latest.svelte
+++ b/src/lib/tests/components/keep_latest.svelte
@@ -20,16 +20,24 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform options</button
 >
 

--- a/src/lib/tests/components/link/child.svelte
+++ b/src/lib/tests/components/link/child.svelte
@@ -6,11 +6,19 @@
 	export let kind: string;
 
 	const default_task = task.default(async (_, { link }) => {
-		await link(parent).perform(0);
+		try {
+			await link(parent).perform(0);
+		} catch {
+			/** empty */
+		}
 	});
 	const options_task = task(
 		async (_, { link }) => {
-			await link(parent).perform(0);
+			try {
+				await link(parent).perform(0);
+			} catch {
+				/** */
+			}
 		},
 		{ kind: 'default' },
 	);
@@ -19,10 +27,14 @@
 <button
 	data-testid="child-component-perform-{kind}"
 	on:click={async () => {
-		if (kind === 'default') {
-			default_task.perform();
-		} else {
-			options_task.perform();
+		try {
+			if (kind === 'default') {
+				await default_task.perform();
+			} else {
+				await options_task.perform();
+			}
+		} catch {
+			/**empty*/
 		}
 	}}>perform</button
 >

--- a/src/lib/tests/components/link/parent.svelte
+++ b/src/lib/tests/components/link/parent.svelte
@@ -14,11 +14,19 @@
 	const options_task = task(fn, { kind: 'default' });
 
 	const default_task_child = task.default(async (_, { link }) => {
-		await link(default_task).perform(argument);
+		try {
+			await link(default_task).perform(argument);
+		} catch {
+			/** empty */
+		}
 	});
 
 	const default_options_task_child = task.default(async (_, { link }) => {
-		await link(options_task).perform(argument);
+		try {
+			await link(options_task).perform(argument);
+		} catch {
+			/** catch */
+		}
 	});
 
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
@@ -32,30 +40,48 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform options</button
 >
 
 <button
 	data-testid="perform-child-default"
 	on:click={async () => {
-		latest_task_child_instance = default_task_child.perform();
+		try {
+			latest_task_child_instance = default_task_child.perform();
+			await latest_task_child_instance;
+		} catch {
+			/**empty*/
+		}
 	}}>perform child</button
 >
 
 <button
 	data-testid="perform-child-options"
 	on:click={async () => {
-		latest_options_task_child_instance = default_options_task_child.perform();
+		try {
+			latest_options_task_child_instance = default_options_task_child.perform();
+			await latest_options_task_child_instance;
+		} catch {
+			/**empty*/
+		}
 	}}>perform child options</button
 >
 

--- a/src/lib/tests/components/restart.svelte
+++ b/src/lib/tests/components/restart.svelte
@@ -20,16 +20,24 @@
 <button
 	data-testid="perform-default"
 	on:click={async () => {
-		latest_task_instance = default_task.perform(argument);
-		return_value(await latest_task_instance);
+		try {
+			latest_task_instance = default_task.perform(argument);
+			return_value(await latest_task_instance);
+		} catch {
+			/**empty*/
+		}
 	}}>perform</button
 >
 
 <button
 	data-testid="perform-options"
 	on:click={async () => {
-		latest_options_task_instance = options_task.perform(argument);
-		return_value(await latest_options_task_instance);
+		try {
+			latest_options_task_instance = options_task.perform(argument);
+			return_value(await latest_options_task_instance);
+		} catch {
+			/** empty */
+		}
 	}}>perform options</button
 >
 

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -109,6 +109,62 @@ describe.each([
 			});
 		});
 
+		it('it can be rerun after being cancelled using `cancelAll`', async () => {
+			let count = 0;
+			const wait_time = 50;
+			let task_signal: AbortSignal;
+			async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
+				task_signal = signal;
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(component, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}`);
+			perform.click();
+			await wait(20);
+			cancel.click();
+			await vi.waitFor(() => {
+				expect(task_signal.aborted).toBeTruthy();
+			});
+			expect(count).toBe(0);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(count).toBe(1);
+			});
+		});
+
+		it('it can be rerun after the last instance is cancelled', async () => {
+			let count = 0;
+			const wait_time = 50;
+			let task_signal: AbortSignal;
+			async function* fn(_: number, { signal }: SvelteConcurrencyUtils) {
+				task_signal = signal;
+				await wait(wait_time);
+				yield;
+				count++;
+			}
+			const { getByTestId } = render(component, {
+				fn,
+			});
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}-last`);
+			perform.click();
+			await wait(20);
+			cancel.click();
+			await vi.waitFor(() => {
+				expect(task_signal.aborted).toBeTruthy();
+			});
+			expect(count).toBe(0);
+			perform.click();
+			await vi.waitFor(() => {
+				expect(count).toBe(1);
+			});
+		});
+
 		it("doesn't runs to completion if it's cancelled, the function is a generator and there's a yield after every await", async () => {
 			let count = 0;
 			const wait_time = 50;

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { render, waitFor } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { describe, expect, it, vi } from 'vitest';
 import type { SvelteConcurrencyUtils, Task } from '../index';
@@ -293,14 +293,14 @@ describe.each([
 			const store = instance[`${selector}_task`] as Task;
 			const perform = getByTestId(`perform-${selector}`);
 			perform.click();
-			await waitFor(() => expect(fn).toHaveBeenCalled());
+			await vi.waitFor(() => expect(fn).toHaveBeenCalled());
 			expect(get(store).last).toStrictEqual({
 				isRunning: true,
 				isSuccessful: false,
 				isError: false,
 				isCanceled: false,
 			});
-			await waitFor(() => expect(finished).toBeTruthy());
+			await vi.waitFor(() => expect(finished).toBeTruthy());
 			expect(get(store).last).toStrictEqual({
 				isRunning: false,
 				isSuccessful: true,
@@ -324,14 +324,14 @@ describe.each([
 			const store = instance[`${selector}_task`] as Task;
 			const perform = getByTestId(`perform-${selector}`);
 			perform.click();
-			await waitFor(() => expect(fn).toHaveBeenCalled());
+			await vi.waitFor(() => expect(fn).toHaveBeenCalled());
 			expect(get(store).lastRunning).toStrictEqual({
 				isRunning: true,
 				isSuccessful: false,
 				isError: false,
 				isCanceled: false,
 			});
-			await waitFor(() => expect(finished).toBeTruthy());
+			await vi.waitFor(() => expect(finished).toBeTruthy());
 			expect(get(store).lastRunning).toBeUndefined();
 		});
 
@@ -349,13 +349,13 @@ describe.each([
 			const store = instance[`${selector}_task`] as Task;
 			const perform = getByTestId(`perform-${selector}`);
 			perform.click();
-			await waitFor(() => expect(fn).toHaveBeenCalled());
+			await vi.waitFor(() => expect(fn).toHaveBeenCalled());
 			expect(get(store).lastCanceled).toBeUndefined();
-			await waitFor(() => expect(finished).toBeTruthy());
+			await vi.waitFor(() => expect(finished).toBeTruthy());
 			expect(get(store).lastCanceled).toBeUndefined();
 			finished = false;
 			perform.click();
-			await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+			await vi.waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
 			const cancel = getByTestId(`cancel-${selector}-last`);
 			cancel.click();
 			expect(get(store).lastCanceled).toStrictEqual({
@@ -387,15 +387,15 @@ describe.each([
 		const store = instance.default_task as Task;
 		const perform = getByTestId(`perform-error`);
 		perform.click();
-		await waitFor(() => expect(fn).toHaveBeenCalled());
+		await vi.waitFor(() => expect(fn).toHaveBeenCalled());
 		expect(get(store).lastErrored).toBeUndefined();
-		await waitFor(() => expect(finished).toBeTruthy());
+		await vi.waitFor(() => expect(finished).toBeTruthy());
 		expect(get(store).lastErrored).toBeUndefined();
 		finished = false;
 		error = new Error();
 		perform.click();
-		await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
-		await waitFor(() => expect(returned_value).toBeDefined());
+		await vi.waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(returned_value).toBeDefined());
 		expect(get(store).lastErrored).toStrictEqual({
 			error,
 			isRunning: false,
@@ -426,15 +426,15 @@ describe.each([
 		const store = instance.default_task as Task;
 		const perform = getByTestId(`perform-error`);
 		perform.click();
-		await waitFor(() => expect(fn).toHaveBeenCalled());
+		await vi.waitFor(() => expect(fn).toHaveBeenCalled());
 		expect(get(store).lastSuccessful).toBeUndefined();
-		await waitFor(() => expect(returned_value).toBeDefined());
+		await vi.waitFor(() => expect(returned_value).toBeDefined());
 		expect(get(store).lastSuccessful).toBeUndefined();
 		finished = false;
 		error = undefined;
 		perform.click();
-		await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
-		await waitFor(() => expect(finished).toBeTruthy());
+		await vi.waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(finished).toBeTruthy());
 		expect(get(store).lastSuccessful).toStrictEqual({
 			isRunning: false,
 			isSuccessful: true,
@@ -843,11 +843,11 @@ describe('link - invoke a task inside a task and cancel the instance if parent i
 			const perform = getByTestId(`perform-child-${selector}`);
 			const cancel = getByTestId(`cancel-child-${selector}`);
 			perform.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(fn).toHaveBeenCalled();
 			});
 			cancel.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(finish_waiting).toBeTruthy();
 			});
 			expect(cancelled).toBeTruthy();
@@ -869,11 +869,11 @@ describe('link - invoke a task inside a task and cancel the instance if parent i
 			const perform = getByTestId(`perform-child-${selector}`);
 			const cancel = getByTestId(`cancel-child-${selector}-last`);
 			perform.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(fn).toHaveBeenCalled();
 			});
 			cancel.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(finish_waiting).toBeTruthy();
 			});
 			expect(cancelled).toBeTruthy();
@@ -895,11 +895,11 @@ describe('link - invoke a task inside a task and cancel the instance if parent i
 			const perform = getByTestId(`child-component-perform-${selector}`);
 			const cancel = getByTestId(`unmount-child-component`);
 			perform.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(fn).toHaveBeenCalled();
 			});
 			cancel.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(finish_waiting).toBeTruthy();
 			});
 			expect(cancelled).toBeTruthy();
@@ -924,11 +924,11 @@ describe('link - invoke a task inside a task and cancel the instance if parent i
 			const cancel = getByTestId(`cancel-child-${selector}-last`);
 			perform.click();
 			perform.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(fn).toHaveBeenCalledTimes(2);
 			});
 			cancel.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(finish_waiting[0]).toBeTruthy();
 				expect(finish_waiting[1]).toBeTruthy();
 			});
@@ -956,11 +956,11 @@ describe('link - invoke a task inside a task and cancel the instance if parent i
 			const cancel = getByTestId(`unmount-child-component`);
 			perform_parent.click();
 			perform_child.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(fn).toHaveBeenCalledTimes(2);
 			});
 			cancel.click();
-			await waitFor(() => {
+			await vi.waitFor(() => {
 				expect(finish_waiting[0]).toBeTruthy();
 				expect(finish_waiting[1]).toBeTruthy();
 			});


### PR DESCRIPTION
Closes #93 and probably #94 too

Pretty nasty bug: when cancelled we need to resolve the promise in some way or it will hang indefinitely. This was shown in task types that were waiting for the old one to finish but it was a general bug.

For the moment i've opted into rejecting the promise with a Custom Error so that the user can check against that instance if the task has been cancelled. This feels the right thing to do but i would love your opinion on this when you are back from vacation @beerinho @nickschot 

I also realized that we were doing something wrong with the restart so i moved the array to be a set and removed that specific instance instead of popping the array.